### PR TITLE
Align AppDelegate changeFont(_:) with NSFontChanging protocol

### DIFF
--- a/Sources/SignboardApp/AppDelegate.swift
+++ b/Sources/SignboardApp/AppDelegate.swift
@@ -189,8 +189,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSFontChanging, NSUser
         return true
     }
 
-    @objc func changeFont(_ sender: Any?) {
-        guard let manager = sender as? NSFontManager else {
+    @MainActor @objc func changeFont(_ sender: NSFontManager?) {
+        guard let manager = sender else {
             return
         }
         let converted = manager.convert(currentFont())


### PR DESCRIPTION
## Summary
- update AppDelegate.changeFont signature from Any to NSFontManager optional
- add MainActor annotation to match NSFontChanging protocol requirement
- keep nil sender behavior unchanged

## Validation
- attempted swift build, but local toolchain and SDK mismatch prevented verification in this environment

Fixes #1