### PR TITLE
Implement distributable app packaging with bundled CLI (issue #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .build/
 .swiftpm/
 Package.resolved
+dist/
 
 # Xcode
 DerivedData/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,48 @@ swift build
 swift run SignboardApp
 ```
 
+## Build Distributable App Bundle
+
+Create a distributable artifact at `dist/SignboardApp.app`:
+
+```bash
+./scripts/package-app.sh
+```
+
+Optional release zip:
+
+```bash
+CREATE_ZIP=1 ./scripts/package-app.sh
+```
+
+Version metadata source:
+
+- `CFBundleShortVersionString`: `APP_VERSION` env var, defaulting to `SignboardVersion.current`
+- `CFBundleVersion`: `APP_BUILD_VERSION` env var, defaulting to `APP_VERSION`
+
+Example:
+
+```bash
+APP_VERSION=0.2.0 APP_BUILD_VERSION=20260213 ./scripts/package-app.sh
+```
+
+## Bundle Verification Commands
+
+```bash
+# 1) Build the artifact
+./scripts/package-app.sh
+
+# 2) Launch bundled GUI app
+open dist/SignboardApp.app
+
+# 3) Run bundled CLI from inside the app bundle
+dist/SignboardApp.app/Contents/MacOS/signboard --version
+dist/SignboardApp.app/Contents/MacOS/signboard list
+dist/SignboardApp.app/Contents/MacOS/signboard create "Packaged app smoke test"
+```
+
+The bundled CLI requires the bundled app to be running, same as local development.
+
 ## End-User Quick Start
 
 1. Launch `SignboardApp`.

--- a/Sources/SignboardApp/Localization.swift
+++ b/Sources/SignboardApp/Localization.swift
@@ -1,7 +1,57 @@
 import Foundation
 
 enum L10n {
+    private static let tableName = "Localizable"
+    private static let resourceBundleName = "Signboard_SignboardApp"
+    private static let bundle: Bundle = {
+        for candidate in candidateBundles() {
+            if hasLocalizations(in: candidate) {
+                return candidate
+            }
+        }
+        return .module
+    }()
+
     static func tr(_ key: String, comment: String) -> String {
-        NSLocalizedString(key, tableName: nil, bundle: .module, value: key, comment: comment)
+        NSLocalizedString(key, tableName: tableName, bundle: bundle, value: key, comment: comment)
+    }
+
+    private static func candidateBundles() -> [Bundle] {
+        var bundles: [Bundle] = [.module, .main]
+
+        if let mainResourceURL = Bundle.main.resourceURL {
+            let nestedResourceBundleURL = mainResourceURL.appendingPathComponent("\(resourceBundleName).bundle")
+            if let nestedResourceBundle = Bundle(url: nestedResourceBundleURL) {
+                bundles.append(nestedResourceBundle)
+            }
+        }
+
+        if let executableURL = Bundle.main.executableURL {
+            let resourcesURL = executableURL
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Resources")
+            let nestedResourceBundleURL = resourcesURL.appendingPathComponent("\(resourceBundleName).bundle")
+            if let nestedResourceBundle = Bundle(url: nestedResourceBundleURL) {
+                bundles.append(nestedResourceBundle)
+            }
+        }
+
+        var uniqueBundles: [Bundle] = []
+        var seenURLs = Set<URL>()
+
+        for bundle in bundles {
+            let resolvedURL = bundle.bundleURL.resolvingSymlinksInPath()
+            if seenURLs.insert(resolvedURL).inserted {
+                uniqueBundles.append(bundle)
+            }
+        }
+
+        return uniqueBundles
+    }
+
+    private static func hasLocalizations(in bundle: Bundle) -> Bool {
+        bundle.path(forResource: tableName, ofType: "strings", inDirectory: nil, forLocalization: "en") != nil ||
+            bundle.path(forResource: "en", ofType: "lproj") != nil
     }
 }

--- a/Sources/SignboardCore/SignboardCoreModels.swift
+++ b/Sources/SignboardCore/SignboardCoreModels.swift
@@ -4,6 +4,21 @@ public enum SignboardVersion {
     public static let current = "0.1.0"
 
     public static func displayString(bundle: Bundle = .main) -> String {
+        if let fromBundle = displayStringIfPresent(in: bundle) {
+            return fromBundle
+        }
+
+        if let appBundle = enclosingAppBundle(),
+           appBundle.bundleURL != bundle.bundleURL,
+           let fromAppBundle = displayStringIfPresent(in: appBundle)
+        {
+            return fromAppBundle
+        }
+
+        return current
+    }
+
+    private static func displayStringIfPresent(in bundle: Bundle) -> String? {
         let shortVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let buildVersion = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
 
@@ -18,7 +33,26 @@ public enum SignboardVersion {
             return buildVersion
         }
 
-        return current
+        return nil
+    }
+
+    private static func enclosingAppBundle() -> Bundle? {
+        guard let executableURL = Bundle.main.executableURL?.resolvingSymlinksInPath() else {
+            return nil
+        }
+
+        var candidateURL = executableURL.deletingLastPathComponent()
+        while candidateURL.path != "/" {
+            if candidateURL.pathExtension == "app" {
+                return Bundle(url: candidateURL)
+            }
+            let parentURL = candidateURL.deletingLastPathComponent()
+            if parentURL.path == candidateURL.path {
+                break
+            }
+            candidateURL = parentURL
+        }
+        return nil
     }
 }
 

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+CONFIGURATION="${CONFIGURATION:-release}"
+DIST_DIR="${DIST_DIR:-${ROOT_DIR}/dist}"
+APP_NAME="${APP_NAME:-SignboardApp}"
+APP_IDENTIFIER="${APP_IDENTIFIER:-com.dayflower.signboard}"
+RESOURCE_BUNDLE_NAME="${RESOURCE_BUNDLE_NAME:-Signboard_SignboardApp.bundle}"
+CREATE_ZIP="${CREATE_ZIP:-0}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
+
+APP_BUNDLE_PATH="${DIST_DIR}/${APP_NAME}.app"
+ZIP_PATH="${DIST_DIR}/${APP_NAME}.zip"
+CACHE_DIR="${ROOT_DIR}/.build/local-cache"
+VERSION_SOURCE="${ROOT_DIR}/Sources/SignboardCore/SignboardCoreModels.swift"
+
+mkdir -p "${CACHE_DIR}/swiftpm-module-cache" "${CACHE_DIR}/clang-module-cache"
+export SWIFTPM_MODULECACHE_OVERRIDE="${CACHE_DIR}/swiftpm-module-cache"
+export CLANG_MODULE_CACHE_PATH="${CACHE_DIR}/clang-module-cache"
+
+if [[ "${SKIP_BUILD}" != "1" ]]; then
+    swift build -c "${CONFIGURATION}" --product SignboardApp
+    swift build -c "${CONFIGURATION}" --product signboard
+fi
+
+BIN_PATH="$(swift build -c "${CONFIGURATION}" --show-bin-path)"
+GUI_EXECUTABLE_PATH="${BIN_PATH}/SignboardApp"
+CLI_EXECUTABLE_PATH="${BIN_PATH}/signboard"
+RESOURCE_BUNDLE_PATH="${BIN_PATH}/${RESOURCE_BUNDLE_NAME}"
+
+for path in "${GUI_EXECUTABLE_PATH}" "${CLI_EXECUTABLE_PATH}" "${RESOURCE_BUNDLE_PATH}"; do
+    if [[ ! -e "${path}" ]]; then
+        echo "Expected build output not found: ${path}" >&2
+        exit 1
+    fi
+done
+
+DEFAULT_VERSION="$(sed -nE 's/^[[:space:]]*public static let current = "([^"]+)".*/\1/p' "${VERSION_SOURCE}" | head -n 1)"
+if [[ -z "${DEFAULT_VERSION}" ]]; then
+    echo "Could not resolve default app version from ${VERSION_SOURCE}" >&2
+    exit 1
+fi
+
+APP_VERSION="${APP_VERSION:-${DEFAULT_VERSION}}"
+APP_BUILD_VERSION="${APP_BUILD_VERSION:-${APP_VERSION}}"
+
+rm -rf "${APP_BUNDLE_PATH}"
+mkdir -p "${APP_BUNDLE_PATH}/Contents/MacOS" "${APP_BUNDLE_PATH}/Contents/Resources"
+
+install -m 755 "${GUI_EXECUTABLE_PATH}" "${APP_BUNDLE_PATH}/Contents/MacOS/SignboardApp"
+install -m 755 "${CLI_EXECUTABLE_PATH}" "${APP_BUNDLE_PATH}/Contents/MacOS/signboard"
+cp -R "${RESOURCE_BUNDLE_PATH}" "${APP_BUNDLE_PATH}/Contents/Resources/${RESOURCE_BUNDLE_NAME}"
+
+cat > "${APP_BUNDLE_PATH}/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundleExecutable</key>
+    <string>SignboardApp</string>
+    <key>CFBundleIdentifier</key>
+    <string>${APP_IDENTIFIER}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${APP_VERSION}</string>
+    <key>CFBundleVersion</key>
+    <string>${APP_BUILD_VERSION}</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>
+PLIST
+
+if [[ "${CREATE_ZIP}" == "1" ]]; then
+    rm -f "${ZIP_PATH}"
+    ditto -c -k --sequesterRsrc --keepParent "${APP_BUNDLE_PATH}" "${ZIP_PATH}"
+fi
+
+echo "Created ${APP_BUNDLE_PATH}"
+if [[ "${CREATE_ZIP}" == "1" ]]; then
+    echo "Created ${ZIP_PATH}"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/package-app.sh` to build and assemble a distributable `dist/SignboardApp.app` with both `SignboardApp` (GUI) and `signboard` (CLI)
- include `Signboard_SignboardApp.bundle` in `Contents/Resources` and generate `Contents/Info.plist` with configurable version metadata
- improve runtime fallback for resource localization lookup in packaged `.app` layout (`L10n` bundle resolution)
- improve version lookup fallback so bundled CLI can read app version from enclosing `.app` when needed
- document packaging and verification commands in `README.md` and ignore `dist/` artifacts in `.gitignore`

## Verification
- `swift build`
- `./scripts/package-app.sh`
- `dist/SignboardApp.app/Contents/MacOS/signboard --version`
- `dist/SignboardApp.app/Contents/MacOS/signboard list`
- `dist/SignboardApp.app/Contents/MacOS/signboard update -i <id> <text>`

Closes #5
