### PR TITLE
feat: automate Homebrew cask bump workflow on release publish

### DIFF
--- a/.github/workflows/bump-homebrew-cask.yml
+++ b/.github/workflows/bump-homebrew-cask.yml
@@ -1,0 +1,27 @@
+name: Bump Homebrew Cask
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bump-homebrew-cask:
+    runs-on: macos-14
+    steps:
+      - name: Configure git user
+        uses: Homebrew/actions/git-user-config@main
+        with:
+          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          username: UpdateBrew
+
+      - name: Bump Signboard cask
+        uses: Homebrew/actions/bump-packages@main
+        with:
+          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          casks: dayflower/tap/signboard
+          fork: false

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Checksum verification (from repository root):
 shasum -a 256 -c dist/SignboardApp-0.2.0.zip.sha256
 ```
 
+## Homebrew Tap Automation (GitHub Actions)
+
+Publishing a GitHub Release triggers `.github/workflows/bump-homebrew-cask.yml`.
+This workflow runs `Homebrew/actions/bump-packages` for `dayflower/tap/signboard`,
+which updates cask metadata (version/checksum/url) in `dayflower/homebrew-tap`
+and opens or updates a pull request when a bump is needed.
+
+Required repository secret:
+
+- `HOMEBREW_GITHUB_API_TOKEN` with permission to push branches and open pull requests in `dayflower/homebrew-tap`
+
 ## Bundle Verification Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- add `.github/workflows/bump-homebrew-cask.yml`
- trigger Homebrew bump on `release.published` and support `workflow_dispatch`
- configure `Homebrew/actions/git-user-config` and `Homebrew/actions/bump-packages` with `HOMEBREW_GITHUB_API_TOKEN`
- document Homebrew tap automation requirements in `README.md`

## Related
- Fixes #6