### PR TITLE
fix: set Homebrew git-user-config username to BrewTestBot

### DIFF
--- a/.github/workflows/bump-homebrew-cask.yml
+++ b/.github/workflows/bump-homebrew-cask.yml
@@ -17,7 +17,7 @@ jobs:
         uses: Homebrew/actions/git-user-config@main
         with:
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-          username: UpdateBrew
+          username: BrewTestBot
 
       - name: Bump Signboard cask
         uses: Homebrew/actions/bump-packages@main


### PR DESCRIPTION
## Summary
- update .github/workflows/bump-homebrew-cask.yml
- change git-user-config username from UpdateBrew to BrewTestBot

## Why
- Homebrew action requires an existing GitHub user account for username