### PR TITLE
fix: make Homebrew cask bump workflow resilient on hosted runners

### DIFF
--- a/.github/workflows/bump-homebrew-cask.yml
+++ b/.github/workflows/bump-homebrew-cask.yml
@@ -19,6 +19,19 @@ jobs:
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           username: BrewTestBot
 
+      - name: Tap dayflower/tap
+        run: brew tap dayflower/tap
+
+      - name: Preflight cask availability
+        shell: bash
+        run: |
+          set -euo pipefail
+          cask="dayflower/tap/signboard"
+          if ! brew info --cask "$cask"; then
+            echo "::error title=Homebrew cask preflight failed::Unable to resolve $cask after tapping dayflower/tap. Verify that the cask exists in dayflower/homebrew-tap and that HOMEBREW_GITHUB_API_TOKEN can access it."
+            exit 1
+          fi
+
       - name: Bump Signboard cask
         uses: Homebrew/actions/bump-packages@main
         with:

--- a/README.md
+++ b/README.md
@@ -85,9 +85,13 @@ shasum -a 256 -c dist/SignboardApp-0.2.0.zip.sha256
 ## Homebrew Tap Automation (GitHub Actions)
 
 Publishing a GitHub Release triggers `.github/workflows/bump-homebrew-cask.yml`.
-This workflow runs `Homebrew/actions/bump-packages` for `dayflower/tap/signboard`,
-which updates cask metadata (version/checksum/url) in `dayflower/homebrew-tap`
-and opens or updates a pull request when a bump is needed.
+The workflow first runs `brew tap dayflower/tap`, then validates cask resolution with
+`brew info --cask dayflower/tap/signboard` before calling
+`Homebrew/actions/bump-packages`.
+If the preflight check fails, the workflow exits early with a clear diagnostic message.
+When preflight succeeds, `bump-packages` updates cask metadata
+(version/checksum/url) in `dayflower/homebrew-tap` and opens or updates a pull
+request when a bump is needed.
 
 Required repository secret:
 


### PR DESCRIPTION
## Summary
- add an explicit `brew tap dayflower/tap` step before bump execution
- add a preflight cask availability check using `brew info --cask dayflower/tap/signboard`
- fail fast with an actionable diagnostic message when preflight fails
- document tap setup and preflight behavior in the README automation section

## Validation
- YAML parse check: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bump-homebrew-cask.yml"); puts "workflow yaml ok"'`
- workflow_dispatch execution verification is pending (not run from this environment)

Closes #13
