### PR TITLE
docs: restructure README for users and split development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,94 +27,21 @@ You can treat each signboard as a lightweight visual anchor for each Space.
 - **Persistent** — Signboards are saved and restored across launches
 - **Modifier-based interaction** — Reposition panels and open context menus while holding a modifier key
 
-## Build & Run
+## Install (Homebrew)
 
 ```bash
-swift build
-swift run SignboardApp
+brew tap dayflower/tap
+brew install --cask dayflower/tap/signboard
 ```
 
-## Build Distributable App Bundle
+## Install (GitHub Releases)
 
-Create a distributable artifact at `dist/SignboardApp.app`:
+1. Open the latest release page: [GitHub Releases](https://github.com/dayflower/Signboard/releases/latest)
+2. Download `SignboardApp-<version>.zip` (and `SignboardApp-<version>.zip.sha256` if you want checksum verification).
+3. Unzip and move `SignboardApp.app` to `/Applications`.
+4. Launch `SignboardApp`.
 
-```bash
-./scripts/package-app.sh
-```
-
-Optional release zip:
-
-```bash
-CREATE_ZIP=1 ./scripts/package-app.sh
-```
-
-Version metadata source:
-
-- `CFBundleShortVersionString`: `APP_VERSION` env var, defaulting to `SignboardVersion.current`
-- `CFBundleVersion`: `APP_BUILD_VERSION` env var, defaulting to `APP_VERSION`
-
-Example:
-
-```bash
-APP_VERSION=0.2.0 APP_BUILD_VERSION=20260213 ./scripts/package-app.sh
-```
-
-## Release Automation (GitHub Actions)
-
-Tag pushes that match `vX.Y.Z` trigger `.github/workflows/release.yml`.
-The tag version must match `SignboardVersion.current` in source.
-
-Generated release assets:
-
-- `SignboardApp-<version>.zip`
-- `SignboardApp-<version>.zip.sha256`
-
-Release a new version:
-
-```bash
-git tag v0.2.0
-git push origin v0.2.0
-```
-
-Checksum verification (from repository root):
-
-```bash
-shasum -a 256 -c dist/SignboardApp-0.2.0.zip.sha256
-```
-
-## Homebrew Tap Automation (GitHub Actions)
-
-Publishing a GitHub Release triggers `.github/workflows/bump-homebrew-cask.yml`.
-The workflow first runs `brew tap dayflower/tap`, then validates cask resolution with
-`brew info --cask dayflower/tap/signboard` before calling
-`Homebrew/actions/bump-packages`.
-If the preflight check fails, the workflow exits early with a clear diagnostic message.
-When preflight succeeds, `bump-packages` updates cask metadata
-(version/checksum/url) in `dayflower/homebrew-tap` and opens or updates a pull
-request when a bump is needed.
-
-Required repository secret:
-
-- `HOMEBREW_GITHUB_API_TOKEN` with permission to push branches and open pull requests in `dayflower/homebrew-tap`
-
-## Bundle Verification Commands
-
-```bash
-# 1) Build the artifact
-./scripts/package-app.sh
-
-# 2) Launch bundled GUI app
-open dist/SignboardApp.app
-
-# 3) Run bundled CLI from inside the app bundle
-dist/SignboardApp.app/Contents/MacOS/signboard --version
-dist/SignboardApp.app/Contents/MacOS/signboard list
-dist/SignboardApp.app/Contents/MacOS/signboard create "Packaged app smoke test"
-```
-
-The bundled CLI requires the bundled app to be running, same as local development.
-
-## End-User Quick Start
+## Quick Start
 
 1. Launch `SignboardApp`.
 2. Open the menu bar item (signpost icon) and choose **New Signboard**.
@@ -154,6 +81,36 @@ signboard update -i {id} "Updated text"
 signboard hide-all
 signboard show-all
 ```
+
+## Update
+
+Homebrew:
+
+```bash
+brew upgrade --cask dayflower/tap/signboard
+```
+
+GitHub Releases:
+
+1. Download the latest `SignboardApp-<version>.zip` from [GitHub Releases](https://github.com/dayflower/Signboard/releases/latest).
+2. Replace your existing `SignboardApp.app` with the new one.
+
+## Uninstall
+
+Homebrew:
+
+```bash
+brew uninstall --cask dayflower/tap/signboard
+```
+
+GitHub Releases:
+
+1. Quit `SignboardApp`.
+2. Remove `SignboardApp.app` from `/Applications`.
+
+## For Contributors
+
+Developer documentation is available in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Preferences
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,128 @@
+# Development Guide
+
+This document covers local development and release operations.
+For end-user installation and usage, see [README.md](../README.md).
+
+## Requirements
+
+- macOS 13 or later
+- Xcode command line tools
+- Swift 5.9+
+
+## Local Build
+
+```bash
+swift build
+```
+
+## Local Run
+
+Run the app:
+
+```bash
+swift run SignboardApp
+```
+
+In another terminal, run CLI commands:
+
+```bash
+swift run signboard --version
+swift run signboard list
+swift run signboard create "Hello, World!"
+```
+
+The CLI requires `SignboardApp` to be running.
+
+## Packaging
+
+Create a distributable app bundle:
+
+```bash
+./scripts/package-app.sh
+```
+
+Create a zip artifact:
+
+```bash
+CREATE_ZIP=1 ./scripts/package-app.sh
+```
+
+Version metadata is controlled by environment variables:
+
+- `APP_VERSION`: maps to `CFBundleShortVersionString` (default: `SignboardVersion.current`)
+- `APP_BUILD_VERSION`: maps to `CFBundleVersion` (default: `APP_VERSION`)
+
+Example:
+
+```bash
+APP_VERSION=0.2.0 APP_BUILD_VERSION=20260213 ./scripts/package-app.sh
+```
+
+## Bundle Verification
+
+From repository root:
+
+```bash
+# 1) Build the artifact
+./scripts/package-app.sh
+
+# 2) Launch bundled GUI app
+open dist/SignboardApp.app
+
+# 3) Run bundled CLI from inside the app bundle
+dist/SignboardApp.app/Contents/MacOS/signboard --version
+dist/SignboardApp.app/Contents/MacOS/signboard list
+dist/SignboardApp.app/Contents/MacOS/signboard create "Packaged app smoke test"
+```
+
+The bundled CLI also requires the bundled app to be running.
+
+## Release Workflow
+
+Workflow file: `.github/workflows/release.yml`
+
+Trigger:
+
+- Push tag matching `vX.Y.Z`
+
+Main behavior:
+
+1. Validate tag version against `SignboardVersion.current` in `Sources/SignboardCore/SignboardCoreModels.swift`.
+2. Build package artifact with `CREATE_ZIP=1 APP_VERSION=<source version> APP_BUILD_VERSION=<github run number> ./scripts/package-app.sh`.
+3. Rename `dist/SignboardApp.zip` to `dist/SignboardApp-<version>.zip`.
+4. Generate `dist/SignboardApp-<version>.zip.sha256`.
+5. Ensure a release with the same tag does not already exist.
+6. Create a GitHub Release and upload both zip and checksum assets.
+
+Manual release steps:
+
+```bash
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+Checksum verification example:
+
+```bash
+shasum -a 256 -c dist/SignboardApp-0.2.0.zip.sha256
+```
+
+## Homebrew Cask Bump Automation
+
+Workflow file: `.github/workflows/bump-homebrew-cask.yml`
+
+Triggers:
+
+- `release` event with type `published`
+- `workflow_dispatch`
+
+Main behavior:
+
+1. Configure git user via `Homebrew/actions/git-user-config`.
+2. Run `brew tap dayflower/tap`.
+3. Run a preflight check with `brew info --cask dayflower/tap/signboard`.
+4. Run `Homebrew/actions/bump-packages` for `dayflower/tap/signboard`.
+
+Required secret:
+
+- `HOMEBREW_GITHUB_API_TOKEN` with permission to push branches and open pull requests in `dayflower/homebrew-tap`.


### PR DESCRIPTION
## Summary
- Reorganized `README.md` for end users
- Added Homebrew install/update/uninstall and GitHub Releases install/update/uninstall guidance
- Moved developer workflows to `docs/DEVELOPMENT.md`
- Added contributor link from README to development docs

## Scope
- Documentation restructuring only
- No app/CLI behavior changes

## Verification
- Reviewed README and development docs for consistency and removed duplicated/conflicting wording

Closes #4
