### PR TITLE
feat: add Raycast script command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ signboard hide-all
 signboard show-all
 ```
 
+Raycast Script Command examples are available in [examples/raycast](examples/raycast/README.md).
+
 ## Update
 
 Homebrew:

--- a/examples/raycast/README.md
+++ b/examples/raycast/README.md
@@ -1,0 +1,33 @@
+# Raycast Script Commands for Signboard
+
+This directory contains example Raycast Script Commands for Signboard.
+
+## Included Commands
+
+- `create-signboard.sh`: runs `signboard create <text>`
+- `hide-all-signboards.sh`: runs `signboard hide-all`
+- `show-all-signboards.sh`: runs `signboard show-all`
+
+## Behavior
+
+- `create-signboard.sh` accepts only text input. It does not support `-i <id>`.
+- If `SignboardApp` is not running, commands fail with a non-zero exit code.
+- Script feedback is based on process exit code.
+- Scripts assume `signboard` is available in `PATH`.
+
+## Setup
+
+1. Copy the scripts in this directory to your Raycast Script Commands directory.
+2. Make scripts executable:
+
+```bash
+chmod +x create-signboard.sh hide-all-signboards.sh show-all-signboards.sh
+```
+
+3. Open Raycast and run each command once.
+
+## Exit Codes
+
+- `0`: Success
+- Non-zero: Failure
+- `3`: `SignboardApp` is not running (returned by `signboard`)

--- a/examples/raycast/create-signboard.sh
+++ b/examples/raycast/create-signboard.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Signboard: Create
+# @raycast.mode compact
+#
+# Optional parameters:
+# @raycast.packageName Signboard
+# @raycast.argument1 { "type": "text", "placeholder": "Signboard text" }
+#
+# Documentation:
+# @raycast.description Create a signboard via `signboard create`.
+# @raycast.author dayflower
+# @raycast.authorURL https://github.com/dayflower
+
+set -u
+
+text="${1-}"
+if [[ -z "${text// }" ]]; then
+  echo "text is required"
+  exit 1
+fi
+
+signboard create "$text"

--- a/examples/raycast/hide-all-signboards.sh
+++ b/examples/raycast/hide-all-signboards.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Signboard: Hide All
+# @raycast.mode compact
+#
+# Optional parameters:
+# @raycast.packageName Signboard
+#
+# Documentation:
+# @raycast.description Hide all signboards via `signboard hide-all`.
+# @raycast.author dayflower
+# @raycast.authorURL https://github.com/dayflower
+
+signboard hide-all

--- a/examples/raycast/show-all-signboards.sh
+++ b/examples/raycast/show-all-signboards.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Signboard: Show All
+# @raycast.mode compact
+#
+# Optional parameters:
+# @raycast.packageName Signboard
+#
+# Documentation:
+# @raycast.description Show all signboards via `signboard show-all`.
+# @raycast.author dayflower
+# @raycast.authorURL https://github.com/dayflower
+
+signboard show-all


### PR DESCRIPTION
## Summary
Add Raycast Script Command examples for Signboard:
- Create signboard
- Hide all signboards
- Show all signboards

Closes #20.

## Changes
- Add `examples/raycast/create-signboard.sh`
- Add `examples/raycast/hide-all-signboards.sh`
- Add `examples/raycast/show-all-signboards.sh`
- Add `examples/raycast/README.md` with setup and behavior details
- Add a link from root `README.md` to the Raycast examples

## Notes
- `create` supports text input only (no `-i <id>`)
- Commands fail when `SignboardApp` is not running
- Scripts assume `signboard` is in `PATH`
- Success/failure feedback is based on process exit code

## Verification
- `bash -n examples/raycast/create-signboard.sh examples/raycast/hide-all-signboards.sh examples/raycast/show-all-signboards.sh`
- `examples/raycast/create-signboard.sh` returns exit code `1` when text is missing
