### PR TITLE
feat: implement issue #22 delete and delete-all CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ signboard create -i myboard "Status: OK"
 # Update an existing signboard
 signboard update -i {id} "Updated text"
 
+# Delete an existing signboard
+signboard delete -i {id}
+
+# Delete all signboards
+signboard delete-all
+
 # Hide / show all signboards
 signboard hide-all
 signboard show-all

--- a/Sources/SignboardApp/SignboardCommandHandler.swift
+++ b/Sources/SignboardApp/SignboardCommandHandler.swift
@@ -28,6 +28,8 @@ final class SignboardCommandHandler {
             return handleCreate(command)
         case .update:
             return handleUpdate(command)
+        case .delete:
+            return handleDelete(command)
         case .hide:
             return handleHide(command)
         case .show:
@@ -70,6 +72,23 @@ final class SignboardCommandHandler {
         _ = command
         setVisibility(false)
         return SignboardResponse.ok("hidden")
+    }
+
+    private func handleDelete(_ command: SignboardCommand) -> SignboardResponse {
+        if command.all {
+            let count = manager.controllers.count
+            manager.removeAllSignboards()
+            return SignboardResponse.ok("deleted-all \(count)")
+        }
+
+        guard let id = command.id?.trimmingCharacters(in: .whitespacesAndNewlines), !id.isEmpty else {
+            return SignboardResponse.failure(code: 1, message: "ID is required.")
+        }
+        guard manager.signboardController(for: id) != nil else {
+            return SignboardResponse.failure(code: 2, message: "Unknown id: \(id)")
+        }
+        manager.removeSignboard(id: id)
+        return SignboardResponse.ok("deleted \(id)")
     }
 
     private func handleShow(_ command: SignboardCommand) -> SignboardResponse {

--- a/Sources/SignboardCore/SignboardCoreModels.swift
+++ b/Sources/SignboardCore/SignboardCoreModels.swift
@@ -60,6 +60,7 @@ public enum SignboardVersion {
 public enum SignboardAction: String {
     case create
     case update
+    case delete
     case hide
     case show
     case list

--- a/Sources/signboard/main.swift
+++ b/Sources/signboard/main.swift
@@ -7,6 +7,8 @@ private func printUsage() {
       signboard --version
       signboard create [-i id] <text>
       signboard update -i <id> <text>
+      signboard delete -i <id>
+      signboard delete-all
       signboard hide-all
       signboard show-all
       signboard list
@@ -73,6 +75,24 @@ private func parseHideAll(_ args: [String]) -> SignboardCommand? {
         return nil
     }
     return SignboardCommand(action: .hide)
+}
+
+private func parseDelete(_ args: [String]) -> SignboardCommand? {
+    guard args.count == 2, args[0] == "-i" else {
+        return nil
+    }
+    let id = args[1].trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !id.isEmpty else {
+        return nil
+    }
+    return SignboardCommand(action: .delete, id: id, all: false)
+}
+
+private func parseDeleteAll(_ args: [String]) -> SignboardCommand? {
+    guard args.isEmpty else {
+        return nil
+    }
+    return SignboardCommand(action: .delete, all: true)
 }
 
 private func parseShowAll(_ args: [String]) -> SignboardCommand? {
@@ -145,6 +165,10 @@ case "create":
     command = parseCreate(commandArgs)
 case "update":
     command = parseUpdate(commandArgs)
+case "delete":
+    command = parseDelete(commandArgs)
+case "delete-all":
+    command = parseDeleteAll(commandArgs)
 case "hide-all":
     command = parseHideAll(commandArgs)
 case "show-all":


### PR DESCRIPTION
## Summary
- add `delete` action to shared command model
- add CLI commands `signboard delete -i <id>` and `signboard delete-all`
- implement app-side delete handling in `SignboardCommandHandler`
- update CLI usage in `README.md`

## Behavior
- `signboard delete -i <id>`
  - missing/empty ID: code `1`, `ID is required.`
  - unknown ID: code `2`, `Unknown id: <id>`
  - success: code `0`, `deleted <id>`
- `signboard delete-all`
  - success (including empty state): code `0`, `deleted-all <count>`
- app-not-running behavior remains unchanged: code `3`, `SignboardApp is not running.`

## Verification
- `swift build` succeeded
- verified CLI argument validation:
  - `signboard delete` => usage error (exit `1`)
  - `signboard delete-all <extra>` => usage error (exit `1`)
- verified app-not-running compatibility in this sandboxed environment (exit `3`)

Closes #22