### PR TITLE
feat: add Raycast list script command

### DIFF
--- a/examples/raycast/README.md
+++ b/examples/raycast/README.md
@@ -6,6 +6,7 @@ This directory contains example Raycast Script Commands for Signboard.
 
 - `create-signboard.sh`: runs `signboard create <text>`
 - `hide-all-signboards.sh`: runs `signboard hide-all`
+- `list-signboards.sh`: runs `signboard list`
 - `show-all-signboards.sh`: runs `signboard show-all`
 
 ## Behavior
@@ -13,6 +14,7 @@ This directory contains example Raycast Script Commands for Signboard.
 - `create-signboard.sh` accepts only text input. It does not support `-i <id>`.
 - If `SignboardApp` is not running, commands fail with a non-zero exit code.
 - Script feedback is based on process exit code.
+- `list-signboards.sh` prints `No signboards.` only when `signboard list` succeeds with empty stdout.
 - Scripts assume `signboard` is available in `PATH`.
 
 ## Setup
@@ -21,7 +23,7 @@ This directory contains example Raycast Script Commands for Signboard.
 2. Make scripts executable:
 
 ```bash
-chmod +x create-signboard.sh hide-all-signboards.sh show-all-signboards.sh
+chmod +x create-signboard.sh hide-all-signboards.sh list-signboards.sh show-all-signboards.sh
 ```
 
 3. Open Raycast and run each command once.

--- a/examples/raycast/list-signboards.sh
+++ b/examples/raycast/list-signboards.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Signboard: List
+# @raycast.mode fullOutput
+#
+# Optional parameters:
+# @raycast.packageName Signboard
+#
+# Documentation:
+# @raycast.description List signboards via `signboard list`.
+# @raycast.author dayflower
+# @raycast.authorURL https://github.com/dayflower
+
+output_file="$(mktemp)"
+trap 'rm -f "$output_file"' EXIT
+
+signboard list >"$output_file"
+status=$?
+
+if [[ $status -eq 0 ]]; then
+  if [[ -s "$output_file" ]]; then
+    cat "$output_file"
+  else
+    echo "No signboards."
+  fi
+else
+  cat "$output_file"
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary
- add a new Raycast Script Command `examples/raycast/list-signboards.sh` (`Signboard: List`, `fullOutput`)
- run `signboard list` once and map outputs as required:
  - success + non-empty stdout: print as-is
  - success + empty stdout: print `No signboards.`
  - non-zero exit: preserve original exit code and keep CLI error output visible
- update `examples/raycast/README.md` to include `list-signboards.sh` and update the executable setup line

## Verification
- `swift build`
- mock command scenarios for `list-signboards.sh`:
  - non-empty stdout => pass-through / exit `0`
  - empty stdout => `No signboards.` / exit `0`
  - failure with exit `3` => stderr visible / exit `3`
  - other non-zero (`7`) => exit code preserved
- command-not-found scenario => stderr visible / exit `127`
- with `.build/debug/signboard` and app not running => stderr visible (`SignboardApp is not running.`) / exit `3`

Closes #25
