### PR TITLE
feat: add Raycast delete-all script command

### DIFF
--- a/examples/raycast/README.md
+++ b/examples/raycast/README.md
@@ -5,6 +5,7 @@ This directory contains example Raycast Script Commands for Signboard.
 ## Included Commands
 
 - `create-signboard.sh`: runs `signboard create <text>`
+- `delete-all-signboards.sh`: runs `signboard delete-all`
 - `hide-all-signboards.sh`: runs `signboard hide-all`
 - `list-signboards.sh`: runs `signboard list`
 - `show-all-signboards.sh`: runs `signboard show-all`
@@ -12,8 +13,10 @@ This directory contains example Raycast Script Commands for Signboard.
 ## Behavior
 
 - `create-signboard.sh` accepts only text input. It does not support `-i <id>`.
+- `delete-all-signboards.sh` requires confirmation in Raycast before execution.
 - If `SignboardApp` is not running, commands fail with a non-zero exit code.
 - Script feedback is based on process exit code.
+- `delete-all-signboards.sh` forwards CLI error output on failure and prints completion output on success.
 - `list-signboards.sh` prints `No signboards.` only when `signboard list` succeeds with empty stdout.
 - Scripts assume `signboard` is available in `PATH`.
 
@@ -23,7 +26,7 @@ This directory contains example Raycast Script Commands for Signboard.
 2. Make scripts executable:
 
 ```bash
-chmod +x create-signboard.sh hide-all-signboards.sh list-signboards.sh show-all-signboards.sh
+chmod +x create-signboard.sh delete-all-signboards.sh hide-all-signboards.sh list-signboards.sh show-all-signboards.sh
 ```
 
 3. Open Raycast and run each command once.

--- a/examples/raycast/delete-all-signboards.sh
+++ b/examples/raycast/delete-all-signboards.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Signboard: Delete All
+# @raycast.mode compact
+#
+# Optional parameters:
+# @raycast.packageName Signboard
+# @raycast.needsConfirmation true
+#
+# Documentation:
+# @raycast.description Delete all signboards via `signboard delete-all`.
+# @raycast.author dayflower
+# @raycast.authorURL https://github.com/dayflower
+
+output_file="$(mktemp)"
+trap 'rm -f "$output_file"' EXIT
+
+signboard delete-all >"$output_file" 2>&1
+status=$?
+
+if [[ $status -eq 0 ]]; then
+  if [[ -s "$output_file" ]]; then
+    cat "$output_file"
+  else
+    echo "Deleted all signboards."
+  fi
+else
+  cat "$output_file"
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary
- add `examples/raycast/delete-all-signboards.sh` for `signboard delete-all`
- require Raycast confirmation before execution with `@raycast.needsConfirmation true`
- preserve CLI output/exit code behavior: show error output on failure and clear success output on completion
- update `examples/raycast/README.md` Included Commands, Behavior, and setup `chmod` command

## Testing
- `examples/raycast/delete-all-signboards.sh; echo "exit:$?"` (without `signboard` in PATH -> confirms failure output and non-zero exit)
- mocked `signboard` success/failure scripts to verify:
  - success output forwarding and exit `0`
  - failure output forwarding and exit `3`

Closes #24
