### PR TITLE
feat: add Raycast command for deleting one signboard by ID

### DIFF
--- a/examples/raycast/README.md
+++ b/examples/raycast/README.md
@@ -6,6 +6,7 @@ This directory contains example Raycast Script Commands for Signboard.
 
 - `create-signboard.sh`: runs `signboard create <text>`
 - `delete-all-signboards.sh`: runs `signboard delete-all`
+- `delete-signboard.sh`: runs `signboard delete -i <id>`
 - `hide-all-signboards.sh`: runs `signboard hide-all`
 - `list-signboards.sh`: runs `signboard list`
 - `show-all-signboards.sh`: runs `signboard show-all`
@@ -14,9 +15,12 @@ This directory contains example Raycast Script Commands for Signboard.
 
 - `create-signboard.sh` accepts only text input. It does not support `-i <id>`.
 - `delete-all-signboards.sh` requires confirmation in Raycast before execution.
+- `delete-signboard.sh` requires confirmation in Raycast and takes a signboard ID.
+- IDs can be obtained from `Signboard: List`.
 - If `SignboardApp` is not running, commands fail with a non-zero exit code.
 - Script feedback is based on process exit code.
 - `delete-all-signboards.sh` forwards CLI error output on failure and prints completion output on success.
+- `delete-signboard.sh` forwards CLI error output on failure and prints completion output on success.
 - `list-signboards.sh` prints `No signboards.` only when `signboard list` succeeds with empty stdout.
 - Scripts assume `signboard` is available in `PATH`.
 
@@ -26,7 +30,7 @@ This directory contains example Raycast Script Commands for Signboard.
 2. Make scripts executable:
 
 ```bash
-chmod +x create-signboard.sh delete-all-signboards.sh hide-all-signboards.sh list-signboards.sh show-all-signboards.sh
+chmod +x create-signboard.sh delete-all-signboards.sh delete-signboard.sh hide-all-signboards.sh list-signboards.sh show-all-signboards.sh
 ```
 
 3. Open Raycast and run each command once.

--- a/examples/raycast/delete-signboard.sh
+++ b/examples/raycast/delete-signboard.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Signboard: Delete
+# @raycast.mode compact
+#
+# Optional parameters:
+# @raycast.packageName Signboard
+# @raycast.argument1 { "type": "text", "placeholder": "Signboard ID" }
+# @raycast.needsConfirmation true
+#
+# Documentation:
+# @raycast.description Delete a signboard via `signboard delete -i <id>`.
+# @raycast.author dayflower
+# @raycast.authorURL https://github.com/dayflower
+
+set -u
+
+id="${1-}"
+if [[ -z "${id// }" ]]; then
+  echo "id is required"
+  exit 1
+fi
+
+output_file="$(mktemp)"
+trap 'rm -f "$output_file"' EXIT
+
+signboard delete -i "$id" >"$output_file" 2>&1
+status=$?
+
+if [[ $status -eq 0 ]]; then
+  if [[ -s "$output_file" ]]; then
+    cat "$output_file"
+  else
+    echo "Deleted signboard."
+  fi
+else
+  cat "$output_file"
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary
- add `examples/raycast/delete-signboard.sh` for `signboard delete -i <id>`
- validate blank/missing ID with `id is required` and `exit 1`
- preserve CLI output and exit code via temp-file capture
- update `examples/raycast/README.md` with the new command and ID guidance

## Validation
- [x] missing/blank ID returns `exit 1` with `id is required`
- [x] unknown ID path returns `exit 2` and forwards CLI output (validated with mock CLI)
- [x] app not running returns `exit 3` and forwards CLI output
- [x] `signboard` not found returns shell failure (`127`) without masking
- [ ] valid ID deletes exactly one signboard (to be verified in Raycast/manual environment)

Closes #26
