### PR TITLE
docs: clarify Homebrew ad-hoc signing step and reorder CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,6 @@ The CLI requires `SignboardApp` to be running.
 # List all signboards
 signboard list
 
-# Show CLI/App version
-signboard --version
-
 # Create a new signboard
 signboard create "Hello, World!"
 
@@ -94,6 +91,9 @@ signboard delete-all
 # Hide / show all signboards
 signboard hide-all
 signboard show-all
+
+# Show CLI/App version
+signboard --version
 ```
 
 Raycast Script Command examples are available in [examples/raycast](examples/raycast/README.md).

--- a/examples/raycast/README.md
+++ b/examples/raycast/README.md
@@ -4,24 +4,24 @@ This directory contains example Raycast Script Commands for Signboard.
 
 ## Included Commands
 
-- `create-signboard.sh`: runs `signboard create <text>`
-- `delete-all-signboards.sh`: runs `signboard delete-all`
-- `delete-signboard.sh`: runs `signboard delete -i <id>`
-- `hide-all-signboards.sh`: runs `signboard hide-all`
 - `list-signboards.sh`: runs `signboard list`
+- `create-signboard.sh`: runs `signboard create <text>`
+- `delete-signboard.sh`: runs `signboard delete -i <id>`
+- `delete-all-signboards.sh`: runs `signboard delete-all`
+- `hide-all-signboards.sh`: runs `signboard hide-all`
 - `show-all-signboards.sh`: runs `signboard show-all`
 
 ## Behavior
 
+- `list-signboards.sh` prints `No signboards.` only when `signboard list` succeeds with empty stdout.
 - `create-signboard.sh` accepts only text input. It does not support `-i <id>`.
-- `delete-all-signboards.sh` requires confirmation in Raycast before execution.
 - `delete-signboard.sh` requires confirmation in Raycast and takes a signboard ID.
 - IDs can be obtained from `Signboard: List`.
+- `delete-signboard.sh` forwards CLI error output on failure and prints completion output on success.
+- `delete-all-signboards.sh` requires confirmation in Raycast before execution.
+- `delete-all-signboards.sh` forwards CLI error output on failure and prints completion output on success.
 - If `SignboardApp` is not running, commands fail with a non-zero exit code.
 - Script feedback is based on process exit code.
-- `delete-all-signboards.sh` forwards CLI error output on failure and prints completion output on success.
-- `delete-signboard.sh` forwards CLI error output on failure and prints completion output on success.
-- `list-signboards.sh` prints `No signboards.` only when `signboard list` succeeds with empty stdout.
 - Scripts assume `signboard` is available in `PATH`.
 
 ## Setup


### PR DESCRIPTION
## Summary
- add the required post-install `xattr -cr "/Applications/SignboardApp.app"` step in Homebrew install docs
- explain that the step is required because the app is ad-hoc signed (no Apple Developer ID)
- reorder CLI command docs in `README.md` and `examples/raycast/README.md` to a more natural, consistent flow

## Testing
- not run (documentation-only changes)
