### PR TITLE
feat: add launch-at-login toggle to app menu

### DIFF
--- a/Sources/SignboardApp/AppDelegate.swift
+++ b/Sources/SignboardApp/AppDelegate.swift
@@ -1,7 +1,8 @@
 import AppKit
+import ServiceManagement
 import SignboardCore
 
-final class AppDelegate: NSObject, NSApplicationDelegate, NSFontChanging, NSUserInterfaceValidations, SignboardMenuActions {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSFontChanging, NSUserInterfaceValidations, NSMenuDelegate, SignboardMenuActions {
     private let store = SignboardStore()
     private let preferences = AppPreferences.shared
     private lazy var manager = SignboardManager(store: store, preferences: preferences)
@@ -40,12 +41,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSFontChanging, NSUser
     private var isInteractionEnabled = false
     private var statusItem: NSStatusItem?
     private var notificationObserver: NSObjectProtocol?
+    private var launchAtLoginOperation: LaunchAtLoginOperation = .register
+    private var requiresLaunchAtLoginApprovalGuidance = false
+    private var isLaunchAtLoginInFlight = false
+
+    private enum LaunchAtLoginOperation {
+        case register
+        case unregister
+        case unavailable
+    }
+
+    private struct LaunchAtLoginPresentation {
+        let state: NSControl.StateValue
+        let isEnabled: Bool
+        let operation: LaunchAtLoginOperation
+        let requiresApprovalGuidance: Bool
+    }
 
     func applicationDidFinishLaunching(_: Notification) {
         preferences.applyInitialDefaultsIfNeeded()
         NSApp.setActivationPolicy(.accessory)
         buildMainMenu()
         buildStatusItem()
+        refreshLaunchAtLoginMenuState()
 
         manager.loadInitialSignboards(makeController: { [unowned self] signboard in
             self.makeSignboardController(for: signboard)
@@ -114,6 +132,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSFontChanging, NSUser
 
     @objc func toggleVisibility(_: Any?) {
         setVisibility(!isVisible)
+    }
+
+    @objc func toggleLaunchAtLogin(_: Any?) {
+        guard !isLaunchAtLoginInFlight else { return }
+        guard launchAtLoginOperation != .unavailable else { return }
+
+        let shouldShowApprovalGuidance = requiresLaunchAtLoginApprovalGuidance
+        isLaunchAtLoginInFlight = true
+        refreshLaunchAtLoginMenuState()
+        var didFail = false
+        do {
+            switch launchAtLoginOperation {
+            case .register:
+                try SMAppService.mainApp.register()
+            case .unregister:
+                try SMAppService.mainApp.unregister()
+            case .unavailable:
+                break
+            }
+        } catch {
+            didFail = true
+            showLaunchAtLoginErrorAlert(error)
+        }
+        isLaunchAtLoginInFlight = false
+        refreshLaunchAtLoginMenuState()
+
+        if !didFail && (shouldShowApprovalGuidance || requiresLaunchAtLoginApprovalGuidance) {
+            showLaunchAtLoginApprovalRequiredAlert()
+        }
     }
 
     private func setVisibility(_ visible: Bool) {
@@ -263,7 +310,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSFontChanging, NSUser
         let appMenuItem = NSMenuItem()
         mainMenu.addItem(appMenuItem)
 
-        appMenuItem.submenu = menuBuilder.makeAppMenu(appVersion: SignboardVersion.displayString())
+        let appMenu = menuBuilder.makeAppMenu(appVersion: SignboardVersion.displayString())
+        appMenu.delegate = self
+        appMenuItem.submenu = appMenu
         NSApp.mainMenu = mainMenu
     }
 
@@ -274,7 +323,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSFontChanging, NSUser
             button.imagePosition = .imageOnly
             button.title = ""
         }
-        item.menu = menuBuilder.makeAppMenu(appVersion: SignboardVersion.displayString())
+        let appMenu = menuBuilder.makeAppMenu(appVersion: SignboardVersion.displayString())
+        appMenu.delegate = self
+        item.menu = appMenu
         statusItem = item
     }
 
@@ -383,9 +434,58 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSFontChanging, NSUser
         manager.setActiveSignboard(id: id)
         menuBuilder.updateForActiveSignboard(id: id)
     }
+
+    private func refreshLaunchAtLoginMenuState() {
+        let presentation = launchAtLoginPresentation(for: SMAppService.mainApp.status)
+        launchAtLoginOperation = presentation.operation
+        requiresLaunchAtLoginApprovalGuidance = presentation.requiresApprovalGuidance
+        menuBuilder.setLaunchAtLoginMenu(
+            state: presentation.state,
+            isEnabled: presentation.isEnabled && !isLaunchAtLoginInFlight
+        )
+    }
+
+    private func launchAtLoginPresentation(for status: SMAppService.Status) -> LaunchAtLoginPresentation {
+        switch status {
+        case .notRegistered:
+            return LaunchAtLoginPresentation(state: .off, isEnabled: true, operation: .register, requiresApprovalGuidance: false)
+        case .enabled:
+            return LaunchAtLoginPresentation(state: .on, isEnabled: true, operation: .unregister, requiresApprovalGuidance: false)
+        case .requiresApproval:
+            return LaunchAtLoginPresentation(state: .mixed, isEnabled: true, operation: .unregister, requiresApprovalGuidance: true)
+        case .notFound:
+            return LaunchAtLoginPresentation(state: .off, isEnabled: false, operation: .unavailable, requiresApprovalGuidance: false)
+        @unknown default:
+            return LaunchAtLoginPresentation(state: .off, isEnabled: false, operation: .unavailable, requiresApprovalGuidance: false)
+        }
+    }
+
+    private func showLaunchAtLoginErrorAlert(_ error: Error) {
+        let alert = NSAlert()
+        alert.messageText = L10n.tr("alert.launch_at_login.error.title", comment: "Launch-at-login error alert title.")
+        alert.informativeText = String(
+            format: L10n.tr("alert.launch_at_login.error.message_format", comment: "Launch-at-login error alert message format with error detail."),
+            locale: Locale.current,
+            error.localizedDescription
+        )
+        alert.addButton(withTitle: L10n.tr("alert.launch_at_login.button_ok", comment: "Launch-at-login alert button title."))
+        alert.runModal()
+    }
+
+    private func showLaunchAtLoginApprovalRequiredAlert() {
+        let alert = NSAlert()
+        alert.messageText = L10n.tr("alert.launch_at_login.approval_required.title", comment: "Launch-at-login approval-required alert title.")
+        alert.informativeText = L10n.tr("alert.launch_at_login.approval_required.message", comment: "Launch-at-login approval-required alert message.")
+        alert.addButton(withTitle: L10n.tr("alert.launch_at_login.button_ok", comment: "Launch-at-login alert button title."))
+        alert.runModal()
+    }
 }
 
 extension AppDelegate {
+    func menuWillOpen(_: NSMenu) {
+        refreshLaunchAtLoginMenuState()
+    }
+
     private func handleCommand(_ command: SignboardCommand) -> SignboardResponse {
         commandHandler.handle(command)
     }

--- a/Sources/SignboardApp/Resources/en.lproj/Localizable.strings
+++ b/Sources/SignboardApp/Resources/en.lproj/Localizable.strings
@@ -7,6 +7,8 @@
 "menu.app.show_all_signboards" = "Show All Signboards";
 "menu.app.default_text_color" = "Default Text Color";
 "menu.app.drag_modifier" = "Drag Modifier";
+"menu.app.configuration" = "Configuration";
+"menu.app.launch_at_login" = "Launch at Login";
 "menu.app.version_format" = "Version %@";
 "menu.app.quit_signboard" = "Quit Signboard";
 
@@ -35,6 +37,12 @@
 "alert.delete_all_signboards.message" = "This will delete every signboard. This cannot be undone.";
 "alert.delete_all_signboards.button_delete_all" = "Delete All";
 "alert.delete_all_signboards.button_cancel" = "Cancel";
+
+"alert.launch_at_login.error.title" = "Couldn’t Update Launch at Login";
+"alert.launch_at_login.error.message_format" = "Signboard couldn’t update Launch at Login.\n\nError: %@\n\nIf you are running a development build, run the packaged app from /Applications.\nIf approval is needed, open System Settings > Login Items and allow Signboard.";
+"alert.launch_at_login.approval_required.title" = "Approval Required";
+"alert.launch_at_login.approval_required.message" = "Launch at Login needs approval in System Settings.\n\nOpen System Settings > Login Items and allow Signboard.";
+"alert.launch_at_login.button_ok" = "OK";
 
 "signboard.default_name" = "Signboard %d";
 

--- a/Sources/SignboardApp/SignboardMenuBuilder.swift
+++ b/Sources/SignboardApp/SignboardMenuBuilder.swift
@@ -4,6 +4,7 @@ import AppKit
     func createSignboard(_ sender: Any?)
     func deleteAllSignboards(_ sender: Any?)
     func toggleVisibility(_ sender: Any?)
+    func toggleLaunchAtLogin(_ sender: Any?)
     func showFontPanel(_ sender: Any?)
     func selectDragModifier(_ sender: Any?)
     func showSpaceGuide(_ sender: Any?)
@@ -24,6 +25,8 @@ final class SignboardMenuBuilder {
         static let showAllSignboards = L10n.tr("menu.app.show_all_signboards", comment: "App menu item title.")
         static let font = L10n.tr("menu.shared.font", comment: "Shared menu item title.")
         static let spaceGuide = L10n.tr("menu.shared.space_guide", comment: "Shared menu item title.")
+        static let configuration = L10n.tr("menu.app.configuration", comment: "App menu item title.")
+        static let launchAtLogin = L10n.tr("menu.app.launch_at_login", comment: "App menu item title.")
         static let quitSignboard = L10n.tr("menu.app.quit_signboard", comment: "App menu item title.")
         static let editSignboard = L10n.tr("menu.context.edit_signboard", comment: "Context menu item title.")
         static let deleteSignboard = L10n.tr("menu.context.delete_signboard", comment: "Context menu item title.")
@@ -40,6 +43,7 @@ final class SignboardMenuBuilder {
     var preferencesDragModifier: (() -> DragModifier)?
 
     private var toggleVisibilityMenuItems: [NSMenuItem] = []
+    private var launchAtLoginMenuItems: [NSMenuItem] = []
     private var modifierMenuItems: [DragModifier: [NSMenuItem]] = [:]
     private var textColorMenus: [NSMenu] = []
     private var opacityMenus: [NSMenu] = []
@@ -77,6 +81,9 @@ final class SignboardMenuBuilder {
         let helpItem = NSMenuItem(title: MenuTitle.spaceGuide, action: #selector(SignboardMenuActions.showSpaceGuide(_:)), keyEquivalent: "")
         helpItem.target = target
         appMenu.addItem(helpItem)
+
+        appMenu.addItem(NSMenuItem.separator())
+        appMenu.addItem(makeConfigurationMenuItem())
 
         appMenu.addItem(NSMenuItem.separator())
         let versionTitle = String(format: MenuTitle.versionFormat, locale: Locale.current, appVersion)
@@ -125,6 +132,13 @@ final class SignboardMenuBuilder {
         let title = isVisible ? MenuTitle.hideAllSignboards : MenuTitle.showAllSignboards
         for item in toggleVisibilityMenuItems {
             item.title = title
+        }
+    }
+
+    func setLaunchAtLoginMenu(state: NSControl.StateValue, isEnabled: Bool) {
+        for item in launchAtLoginMenuItems {
+            item.state = state
+            item.isEnabled = isEnabled
         }
     }
 
@@ -190,6 +204,21 @@ final class SignboardMenuBuilder {
         if let modifier = preferencesDragModifier?() {
             updateModifierMenuSelection(modifier)
         }
+        return item
+    }
+
+    private func makeConfigurationMenuItem() -> NSMenuItem {
+        let item = NSMenuItem(title: MenuTitle.configuration, action: nil, keyEquivalent: "")
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let launchAtLoginItem = NSMenuItem(title: MenuTitle.launchAtLogin, action: #selector(SignboardMenuActions.toggleLaunchAtLogin(_:)), keyEquivalent: "")
+        launchAtLoginItem.target = target
+        launchAtLoginItem.state = .off
+        menu.addItem(launchAtLoginItem)
+        launchAtLoginMenuItems.append(launchAtLoginItem)
+
+        item.submenu = menu
         return item
     }
 


### PR DESCRIPTION
## Summary
- add `Configuration > Launch at Login` to the shared app/status menus
- map `SMAppService.mainApp.status` to menu state and toggle behavior
- implement register/unregister action with in-flight menu locking and status refresh on launch/menu-open
- add launch-at-login error and approval guidance alerts
- add localization keys for new menu and alert strings

## Testing
- `swift build`

Close #39
