### PR TITLE
fix: sign packaged app bundle and keep launch-at-login actionable

### DIFF
--- a/Sources/SignboardApp/AppDelegate.swift
+++ b/Sources/SignboardApp/AppDelegate.swift
@@ -454,7 +454,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSFontChanging, NSUser
         case .requiresApproval:
             return LaunchAtLoginPresentation(state: .mixed, isEnabled: true, operation: .unregister, requiresApprovalGuidance: true)
         case .notFound:
-            return LaunchAtLoginPresentation(state: .off, isEnabled: false, operation: .unavailable, requiresApprovalGuidance: false)
+            return LaunchAtLoginPresentation(state: .off, isEnabled: true, operation: .register, requiresApprovalGuidance: false)
         @unknown default:
             return LaunchAtLoginPresentation(state: .off, isEnabled: false, operation: .unavailable, requiresApprovalGuidance: false)
         }

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -100,6 +100,11 @@ cat > "${APP_BUNDLE_PATH}/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
+if ! codesign --force --sign - "${APP_BUNDLE_PATH}"; then
+    echo "Failed to code sign app bundle: ${APP_BUNDLE_PATH}" >&2
+    exit 1
+fi
+
 if [[ "${CREATE_ZIP}" == "1" ]]; then
     rm -f "${ZIP_PATH}"
     ditto -c -k --sequesterRsrc --keepParent "${APP_BUNDLE_PATH}" "${ZIP_PATH}"


### PR DESCRIPTION
## Summary
- add ad-hoc app-bundle signing to `scripts/package-app.sh`
- fail packaging explicitly when `codesign` fails
- treat `SMAppService.Status.notFound` as register-capable in launch-at-login menu state

## Validation
- `swift build`
- `./scripts/package-app.sh`
- `codesign -dvv dist/SignboardApp.app` confirms `Identifier=com.dayflower.signboard`
- `codesign --verify --verbose=4 dist/SignboardApp.app`
- manual verification: Launch at Login is interactive from packaged app, ON/OFF toggle works, state re-sync works on menu reopen

Closes #42
