### PR TITLE
feat: sign and notarize releases with a Developer ID identity

### DIFF
--- a/.github/homebrew/signboard.rb.mustache
+++ b/.github/homebrew/signboard.rb.mustache
@@ -1,0 +1,20 @@
+cask "signboard" do
+  version "{{version}}"
+  sha256 "{{artifact.sha256}}"
+
+  url "{{artifact.url}}",
+      verified: "github.com/dayflower/Signboard/"
+  name "Signboard"
+  desc "Floating desktop text panels with menu bar control and CLI automation"
+  homepage "https://github.com/dayflower/Signboard"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+
+  app "SignboardApp.app"
+  binary "SignboardApp.app/Contents/MacOS/signboard"
+end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,17 +39,95 @@ jobs:
           echo "tag_version=${TAG_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "source_version=${VERSION_FILE_VERSION}" >> "${GITHUB_OUTPUT}"
 
+      - name: Verify signing secrets
+        env:
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for name in MACOS_CERTIFICATE_P12 MACOS_CERTIFICATE_PASSWORD \
+            APPLE_API_KEY_ID APPLE_API_ISSUER_ID APPLE_API_KEY_P8; do
+            if [[ -z "${!name}" ]]; then
+              missing+=("${name}")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing required signing secrets: ${missing[*]}" >&2
+            echo "Releases must be signed with a Developer ID identity and notarized; see docs/DEVELOPMENT.md." >&2
+            exit 1
+          fi
+
+      # The action creates a throwaway keychain and removes it again in its post
+      # step, so nothing has to be cleaned up by hand.
+      - name: Import Developer ID certificate
+        uses: Apple-Actions/import-codesign-certs@v7
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+
+      # Pass the identity to package-app.sh by its SHA-1 hash so the
+      # certificate's common name never has to be hardcoded. The action put its
+      # keychain on the search list, so search that rather than guessing where
+      # the file lives; the runner's own login keychain holds no identities.
+      - name: Resolve signing identity
+        run: |
+          set -euo pipefail
+
+          identity="$(security find-identity -v -p codesigning \
+            | awk '/Developer ID Application/ { print $2; exit }')"
+
+          if [[ -z "${identity}" ]]; then
+            echo "No Developer ID Application identity on the keychain search list" >&2
+            security list-keychains >&2
+            security find-identity -v -p codesigning >&2
+            exit 1
+          fi
+
+          echo "CODESIGN_IDENTITY=${identity}" >> "${GITHUB_ENV}"
+
       - name: Build release artifact
+        env:
+          SOURCE_VERSION: ${{ steps.versions.outputs.source_version }}
+        run: |
+          set -euo pipefail
+
+          APP_VERSION="${SOURCE_VERSION}" APP_BUILD_VERSION="${GITHUB_RUN_NUMBER}" ./scripts/package-app.sh
+
+      # Stapling writes the ticket into the bundle, so this has to happen before
+      # the distributed zip is created.
+      - name: Notarize and staple
+        env:
+          NOTARY_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          NOTARY_KEY_BASE64: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+
+          NOTARY_KEY_PATH="${RUNNER_TEMP}/notary-key.p8"
+          export NOTARY_KEY_PATH
+          printf '%s' "${NOTARY_KEY_BASE64}" | base64 --decode > "${NOTARY_KEY_PATH}"
+          ./scripts/notarize-app.sh
+
+      - name: Remove notarization key
+        if: always()
+        run: rm -f "${RUNNER_TEMP}/notary-key.p8"
+
+      - name: Package release artifact
         id: package
         env:
           SOURCE_VERSION: ${{ steps.versions.outputs.source_version }}
         run: |
           set -euo pipefail
 
-          CREATE_ZIP=1 APP_VERSION="${SOURCE_VERSION}" APP_BUILD_VERSION="${GITHUB_RUN_NUMBER}" ./scripts/package-app.sh
-
           ZIP_PATH="dist/SignboardApp-${SOURCE_VERSION}.zip"
-          mv "dist/SignboardApp.zip" "${ZIP_PATH}"
+          rm -f "${ZIP_PATH}"
+          ditto -c -k --sequesterRsrc --keepParent "dist/SignboardApp.app" "${ZIP_PATH}"
           echo "zip_path=${ZIP_PATH}" >> "${GITHUB_OUTPUT}"
 
       - name: Generate checksum
@@ -98,36 +176,20 @@ jobs:
             --title "${GITHUB_REF_NAME}" \
             --notes "Automated release for ${GITHUB_REF_NAME}"
 
-  bump-homebrew-cask:
-    name: Bump Homebrew Cask
-    runs-on: macos-14
-    needs: release
-    if: ${{ needs.release.result == 'success' }}
-    permissions:
-      contents: read
-    steps:
-      - name: Configure git user
-        uses: Homebrew/actions/git-user-config@main
+      # The cask is rendered from .github/homebrew/signboard.rb.mustache in this
+      # repository, so distribution metadata is reviewed alongside app changes.
+      - name: Update Homebrew tap
+        uses: dayflower/brew-up@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
-          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-          username: BrewTestBot
-
-      - name: Tap dayflower/tap
-        run: brew tap dayflower/tap
-
-      - name: Preflight cask availability
-        shell: bash
-        run: |
-          set -euo pipefail
-          cask="dayflower/tap/signboard"
-          if ! brew info --cask "$cask"; then
-            echo "::error title=Homebrew cask preflight failed::Unable to resolve $cask after tapping dayflower/tap. Verify that the cask exists in dayflower/homebrew-tap and that HOMEBREW_GITHUB_API_TOKEN can access it."
-            exit 1
-          fi
-
-      - name: Bump Signboard cask
-        uses: Homebrew/actions/bump-packages@main
-        with:
-          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-          casks: dayflower/tap/signboard
-          fork: false
+          release-tag: ${{ github.ref_name }}
+          template-path: .github/homebrew/signboard.rb.mustache
+          output-path: Casks/signboard.rb
+          asset-map: |
+            default=SignboardApp-{{version}}.zip
+          target-repo: dayflower/homebrew-tap
+          target-branch: main
+          target-repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          publish-mode: pr-auto-merge
+          auto-merge-method: squash

--- a/README.md
+++ b/README.md
@@ -38,14 +38,6 @@ brew tap dayflower/tap
 brew install --cask dayflower/tap/signboard
 ```
 
-After installation, remove quarantine attributes:
-
-```bash
-xattr -cr "/Applications/SignboardApp.app"
-```
-
-This is required because the app uses ad-hoc code signing (no Apple Developer ID).
-
 ## Install (GitHub Releases)
 
 1. Open the latest release page: [GitHub Releases](https://github.com/dayflower/Signboard/releases/latest)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -58,6 +58,39 @@ Example:
 APP_VERSION=0.2.0 APP_BUILD_VERSION=20260213 ./scripts/package-app.sh
 ```
 
+## Signing and Notarization
+
+`scripts/package-app.sh` always signs the bundle. Two Mach-O binaries live in
+`Contents/MacOS` (`SignboardApp` and the bundled `signboard` CLI), so signing runs inside-out:
+the CLI is signed first, then the app bundle, then `codesign --verify --strict` checks the result.
+`scripts/entitlements.plist` is applied in both cases; it is intentionally empty because the app is
+not sandboxed.
+
+Signing behavior is controlled by one environment variable:
+
+- `CODESIGN_IDENTITY` unset (default, local development): ad-hoc signing (`--sign -`).
+- `CODESIGN_IDENTITY` set: signs with that identity plus `--options runtime --timestamp`,
+  which notarization requires. The value may be a certificate common name or its SHA-1 hash.
+
+```bash
+security find-identity -v -p codesigning
+CODESIGN_IDENTITY="<identity hash>" ./scripts/package-app.sh
+codesign -dv --verbose=4 dist/SignboardApp.app
+```
+
+Notarize and staple an already signed bundle:
+
+```bash
+NOTARY_KEY_ID=<key id> \
+NOTARY_ISSUER_ID=<issuer id> \
+NOTARY_KEY_PATH=/path/to/AuthKey_XXXX.p8 \
+  ./scripts/notarize-app.sh
+```
+
+The script submits a throwaway archive to `notarytool`, staples the ticket into the bundle, and
+verifies it with `stapler validate` and `spctl --assess`. Stapling writes into the bundle, so any
+archive built for distribution must be created **after** this script runs.
+
 ## Runtime Resource Contract
 
 - Packaged runtime must resolve localized resources from app bundle paths, not SwiftPM-only lookup (`Bundle.module`).
@@ -149,15 +182,28 @@ Main behavior:
 
 1. Validate tag format and compare tag version (`vX.Y.Z`) to `VERSION`.
 2. Validate `VERSION` and `SignboardVersion.current` consistency.
-3. Build package artifact with `CREATE_ZIP=1 APP_VERSION=<version> APP_BUILD_VERSION=<github run number> ./scripts/package-app.sh`.
-4. Rename `dist/SignboardApp.zip` to `dist/SignboardApp-<version>.zip`.
-5. Generate `dist/SignboardApp-<version>.zip.sha256`.
-6. Ensure a release with the same tag does not already exist.
-7. Create a GitHub Release and upload both zip and checksum assets.
-8. Run the `bump-homebrew-cask` job only after `release` succeeds (`needs: release`).
-9. Configure Homebrew git user and run `brew tap dayflower/tap`.
-10. Run a preflight check with `brew info --cask dayflower/tap/signboard`.
-11. Run `Homebrew/actions/bump-packages` for `dayflower/tap/signboard`.
+3. Fail fast when any signing secret is missing; releases are never published unsigned.
+4. Import the Developer ID certificate into a throwaway keychain (`Apple-Actions/import-codesign-certs`).
+5. Resolve the `Developer ID Application` identity by SHA-1 hash and export it as `CODESIGN_IDENTITY`.
+6. Build package artifact with `APP_VERSION=<version> APP_BUILD_VERSION=<github run number> ./scripts/package-app.sh`.
+7. Notarize and staple with `./scripts/notarize-app.sh`, then delete the decoded API key.
+8. Archive the stapled bundle into `dist/SignboardApp-<version>.zip`.
+9. Generate `dist/SignboardApp-<version>.zip.sha256`.
+10. Ensure a release with the same tag does not already exist.
+11. Create a GitHub Release and upload both zip and checksum assets.
+12. Render `.github/homebrew/signboard.rb.mustache` with `dayflower/brew-up` and publish it to `Casks/signboard.rb` in `dayflower/homebrew-tap` as an auto-merged pull request.
+
+## Homebrew Cask Template
+
+Cask source of truth: `.github/homebrew/signboard.rb.mustache` in this repository.
+
+`dayflower/brew-up` resolves the release assets, injects `{{version}}` and `{{artifact.sha256}}` /
+`{{artifact.url}}`, and pushes the rendered file to the tap. Distribution metadata (`desc`,
+`depends_on`, `app`, `binary`) is therefore edited here and reviewed together with app changes;
+do not edit `Casks/signboard.rb` in the tap repository by hand.
+
+The `asset-map` entry `default=SignboardApp-{{version}}.zip` must keep matching the archive name
+produced by the `Package release artifact` step.
 
 ## PR-first Version Bump Flow
 
@@ -240,6 +286,16 @@ Checksum verification example:
 shasum -a 256 -c dist/SignboardApp-0.2.0.zip.sha256
 ```
 
-Required secret:
+## Required Secrets
+
+Signing and notarization (all required; the release workflow fails when any is missing):
+
+- `MACOS_CERTIFICATE_P12`: base64 of the `Developer ID Application` certificate exported as `.p12`.
+- `MACOS_CERTIFICATE_PASSWORD`: password of that `.p12`.
+- `APPLE_API_KEY_ID`: App Store Connect API key ID.
+- `APPLE_API_ISSUER_ID`: App Store Connect issuer ID.
+- `APPLE_API_KEY_P8`: base64 of the `AuthKey_*.p8` private key.
+
+Homebrew cask bump:
 
 - `HOMEBREW_GITHUB_API_TOKEN` with permission to push branches and open pull requests in `dayflower/homebrew-tap`.

--- a/scripts/entitlements.plist
+++ b/scripts/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Not sandboxed: the app talks to the bundled CLI through
+         DistributedNotificationCenter and registers login items through
+         SMAppService, neither of which needs an entitlement for a
+         Developer ID app running under the hardened runtime. Kept as an
+         explicit (empty) declaration and a hook for future needs, e.g.
+         com.apple.security.get-task-allow when attaching a debugger. -->
+</dict>
+</plist>

--- a/scripts/notarize-app.sh
+++ b/scripts/notarize-app.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Submits the packaged app bundle to Apple's notary service and staples the
+# resulting ticket into the bundle, so Gatekeeper accepts it on machines that
+# have never seen the app and without network access.
+#
+# The bundle must already be signed with a Developer ID identity and the
+# hardened runtime: run scripts/package-app.sh with CODESIGN_IDENTITY set first.
+#
+# Credentials come from an App Store Connect API key:
+#   NOTARY_KEY_ID     Key ID of the key
+#   NOTARY_ISSUER_ID  Issuer ID of the team
+#   NOTARY_KEY_PATH   Path to the AuthKey_*.p8 private key
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DIST_DIR="${DIST_DIR:-${ROOT_DIR}/dist}"
+APP_NAME="${APP_NAME:-SignboardApp}"
+APP_BUNDLE_PATH="${DIST_DIR}/${APP_NAME}.app"
+
+: "${NOTARY_KEY_ID:?NOTARY_KEY_ID is required}"
+: "${NOTARY_ISSUER_ID:?NOTARY_ISSUER_ID is required}"
+: "${NOTARY_KEY_PATH:?NOTARY_KEY_PATH is required}"
+
+if [[ ! -d "${APP_BUNDLE_PATH}" ]]; then
+    echo "App bundle not found: ${APP_BUNDLE_PATH} (run scripts/package-app.sh first)" >&2
+    exit 1
+fi
+
+# notarytool only accepts zip/pkg/dmg, so submit a throwaway archive. The ticket
+# it issues is stapled to the .app itself afterwards, which means any archive
+# built for distribution has to be created after this script runs.
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+ditto -c -k --sequesterRsrc --keepParent "${APP_BUNDLE_PATH}" "${TMP_DIR}/${APP_NAME}.zip"
+
+# --wait exits non-zero unless the submission comes back Accepted. It prints the
+# submission id, so `xcrun notarytool log <id> --key ...` explains a rejection.
+xcrun notarytool submit "${TMP_DIR}/${APP_NAME}.zip" \
+    --key "${NOTARY_KEY_PATH}" \
+    --key-id "${NOTARY_KEY_ID}" \
+    --issuer "${NOTARY_ISSUER_ID}" \
+    --wait
+
+xcrun stapler staple "${APP_BUNDLE_PATH}"
+# Confirm Gatekeeper would let the app run from the stapled ticket alone.
+xcrun stapler validate "${APP_BUNDLE_PATH}"
+spctl --assess --type execute --verbose=4 "${APP_BUNDLE_PATH}"
+
+echo "Notarized ${APP_BUNDLE_PATH}"

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -7,17 +7,19 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CONFIGURATION="${CONFIGURATION:-release}"
 DIST_DIR="${DIST_DIR:-${ROOT_DIR}/dist}"
 APP_NAME="${APP_NAME:-SignboardApp}"
-APP_IDENTIFIER="${APP_IDENTIFIER:-com.dayflower.signboard}"
+APP_IDENTIFIER="${APP_IDENTIFIER:-io.github.dayflower.signboard}"
 RESOURCE_BUNDLE_NAME="${RESOURCE_BUNDLE_NAME:-Signboard_SignboardApp.bundle}"
 APP_ICON_NAME="${APP_ICON_NAME:-AppIcon}"
 APP_ICON_SOURCE="${APP_ICON_SOURCE:-${ROOT_DIR}/Sources/SignboardApp/AppIcon_1024x1024@1x.png}"
 CREATE_ZIP="${CREATE_ZIP:-0}"
 SKIP_BUILD="${SKIP_BUILD:-0}"
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-}"
 
 APP_BUNDLE_PATH="${DIST_DIR}/${APP_NAME}.app"
 ZIP_PATH="${DIST_DIR}/${APP_NAME}.zip"
 CACHE_DIR="${ROOT_DIR}/.build/local-cache"
 ICON_GENERATOR_SCRIPT="${SCRIPT_DIR}/generate-icns.sh"
+ENTITLEMENTS_PATH="${SCRIPT_DIR}/entitlements.plist"
 
 mkdir -p "${CACHE_DIR}/swiftpm-module-cache" "${CACHE_DIR}/clang-module-cache"
 export SWIFTPM_MODULECACHE_OVERRIDE="${CACHE_DIR}/swiftpm-module-cache"
@@ -52,6 +54,11 @@ fi
 
 if [[ ! -x "${ICON_GENERATOR_SCRIPT}" ]]; then
     echo "Expected executable script not found: ${ICON_GENERATOR_SCRIPT}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${ENTITLEMENTS_PATH}" ]]; then
+    echo "Expected entitlements file not found: ${ENTITLEMENTS_PATH}" >&2
     exit 1
 fi
 
@@ -100,8 +107,33 @@ cat > "${APP_BUNDLE_PATH}/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
-if ! codesign --force --sign - "${APP_BUNDLE_PATH}"; then
+# Release signing (CI) sets CODESIGN_IDENTITY to a Developer ID identity and adds
+# the hardened runtime plus a secure timestamp, both required by notarization.
+# Local builds leave it unset and fall back to ad-hoc signing.
+CODESIGN_ARGS=(--force --entitlements "${ENTITLEMENTS_PATH}")
+if [[ -n "${CODESIGN_IDENTITY}" ]]; then
+    CODESIGN_ARGS+=(--options runtime --timestamp --sign "${CODESIGN_IDENTITY}")
+else
+    CODESIGN_ARGS+=(--sign -)
+fi
+
+# Sign inside-out: the bundled CLI is a second Mach-O in Contents/MacOS and is
+# not covered by signing the bundle itself. It has no Info.plist to derive an
+# identifier from, so give it an explicit one instead of the path-derived
+# default; the app bundle takes its identifier from CFBundleIdentifier.
+if ! codesign "${CODESIGN_ARGS[@]}" --identifier "${APP_IDENTIFIER}.cli" \
+    "${APP_BUNDLE_PATH}/Contents/MacOS/signboard"; then
+    echo "Failed to code sign bundled CLI: ${APP_BUNDLE_PATH}/Contents/MacOS/signboard" >&2
+    exit 1
+fi
+
+if ! codesign "${CODESIGN_ARGS[@]}" "${APP_BUNDLE_PATH}"; then
     echo "Failed to code sign app bundle: ${APP_BUNDLE_PATH}" >&2
+    exit 1
+fi
+
+if ! codesign --verify --strict --verbose=2 "${APP_BUNDLE_PATH}"; then
+    echo "Code signature verification failed: ${APP_BUNDLE_PATH}" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Replaces ad-hoc code signing with a Developer ID Application identity plus notarization and stapling in the release workflow, so downloaded builds run without the `xattr -cr` workaround. Modeled on the pipeline in `dayflower/live-transcriber`.

Local development is unchanged: `scripts/package-app.sh` still falls back to ad-hoc signing when `CODESIGN_IDENTITY` is unset. In CI the release fails fast when any signing secret is missing, so an unsigned artifact can never be published by accident.

Two other changes ride along: the app identifier moves to `io.github.dayflower.signboard`, and the Homebrew tap update switches from `Homebrew/actions/bump-packages` to `dayflower/brew-up` driven by a cask template kept in this repository.

## Changes

**Signing**

`scripts/package-app.sh` gains a `CODESIGN_IDENTITY` environment variable. When set, it signs with `--options runtime --timestamp` (both required by notarization); when unset it keeps signing ad-hoc. Signing runs inside-out because `Contents/MacOS` holds two Mach-O binaries: the bundled `signboard` CLI is signed first with an explicit `--identifier`, then the app bundle, then `codesign --verify --strict` checks the result. `scripts/entitlements.plist` is applied in both cases and is intentionally empty, since the app is not sandboxed and neither `DistributedNotificationCenter` nor `SMAppService` needs an entitlement under the hardened runtime.

**Notarization**

New `scripts/notarize-app.sh` submits a throwaway archive to `notarytool`, staples the ticket into the bundle, and verifies with `stapler validate` and `spctl --assess`. Credentials come from an App Store Connect API key.

**Release workflow**

The release job now verifies signing secrets, imports the certificate into a throwaway keychain, resolves the `Developer ID Application` identity by SHA-1 hash (so no common name is hardcoded), builds, notarizes, and only then creates the distribution zip. Stapling writes into the bundle, so the archive has to be built after notarization rather than by `package-app.sh` itself.

**App identifier**

`CFBundleIdentifier` becomes `io.github.dayflower.signboard`. Note this changes the `UserDefaults` domain: existing users start from an empty store, losing saved signboards and preferences, and any login item registered under the old identifier is left orphaned in System Settings. No migration is included.

**Homebrew tap**

The separate `bump-homebrew-cask` job is replaced by a single `dayflower/brew-up` step that renders `.github/homebrew/signboard.rb.mustache` into `Casks/signboard.rb`. The cask is now reviewed alongside app changes, and the ad-hoc `caveats` block is gone. The existing `HOMEBREW_GITHUB_API_TOKEN` secret is reused.

## New secrets required

Before the next release, these repository secrets must exist or the workflow will fail:

`MACOS_CERTIFICATE_P12`, `MACOS_CERTIFICATE_PASSWORD`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID`, `APPLE_API_KEY_P8`

## Verification

Ad-hoc path (`CODESIGN_IDENTITY` unset) still produces `Signature=adhoc`, and `codesign --verify --strict` reports `--validated:` for the nested CLI, confirming inside-out signing is required and working.

Developer ID path, run locally against a real certificate, produces `flags=0x10000(runtime)`, a secure timestamp, `TeamIdentifier`, and the full `Developer ID Application` authority chain on both binaries. The hardened-runtime build launches and the bundled CLI drives it over `DistributedNotificationCenter` as before.

The cask template was rendered with placeholder values and checked with `ruby -c`; `release.yml` parses as valid YAML.

Notarization itself has not been exercised end to end, since that needs the App Store Connect key in CI.
