### PR TITLE
ci: pin GitHub Actions with pinact and restrict workflow permissions

### DIFF
--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,32 @@
+name: pinact
+
+# Verifies that every action referenced by a workflow is pinned to a full commit
+# SHA, and pushes a fixup commit to the pull request branch when it is not.
+#
+# The fixup is pushed with a GitHub App token (vars.ACTIONS_APP_ID /
+# secrets.ACTIONS_APP_PRIVATE_KEY) rather than GITHUB_TOKEN, so the resulting
+# commit re-triggers the other workflows. That is also why checkout must not
+# persist its own credentials and why this workflow only needs contents: read.
+
+on:
+  pull_request:
+
+concurrency:
+  group: pinact-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          app_id: ${{ vars.ACTIONS_APP_ID }}
+          app_private_key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve release version
         id: version
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Verify signing secrets
         env:
@@ -98,7 +98,7 @@ jobs:
       # The action creates a throwaway keychain and removes it again in its post
       # step, so nothing has to be cleaned up by hand.
       - name: Import Developer ID certificate
-        uses: Apple-Actions/import-codesign-certs@v7
+        uses: Apple-Actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
         with:
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -208,7 +208,7 @@ jobs:
       # The cask is rendered from .github/homebrew/signboard.rb.mustache in this
       # repository, so distribution metadata is reviewed alongside app changes.
       - name: Update Homebrew tap
-        uses: dayflower/brew-up@v1
+        uses: dayflower/brew-up@d54916a2db1d7182a4681a6e72adc01022f37794 # v1.1.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate VERSION and SignboardVersion.current
         run: ./scripts/version.sh assert-consistent

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -154,6 +154,32 @@ Main behavior:
 2. Run `./scripts/version.sh assert-consistent`.
 3. Fail checks when `VERSION` and `SignboardVersion.current` differ.
 
+## Action Pinning Guard
+
+Workflow file: `.github/workflows/pinact.yml`
+
+Trigger:
+
+- `pull_request`
+
+[pinact](https://github.com/suzuki-shunsuke/pinact) requires every action referenced by a workflow to
+be pinned to a full commit SHA, so a retagged upstream release cannot change what CI executes. Refs
+carry a `# vX.Y.Z` comment for readability; that comment is what `pinact run` updates when bumping a
+version.
+
+Main behavior:
+
+1. Checkout repository without persisting credentials.
+2. Run `suzuki-shunsuke/pinact-action`, which rewrites unpinned refs and pushes a fixup commit to the
+   pull request branch.
+
+The fixup is pushed with a GitHub App token rather than `GITHUB_TOKEN`, so the resulting commit
+re-triggers the other workflows. That is why the workflow only grants `contents: read`.
+
+To pin refs locally before pushing, install pinact (`brew install pinact`) and run `pinact run`;
+`pinact run --check` reports unpinned refs without editing files. There is no `.pinact.yaml`, so the
+defaults apply to everything under `.github/workflows/`.
+
 ## Release Workflow
 
 Workflow file: `.github/workflows/release.yml`
@@ -277,3 +303,8 @@ Signing and notarization (all required; the release workflow fails when any is m
 Homebrew cask bump:
 
 - `HOMEBREW_GITHUB_API_TOKEN` with permission to push branches and open pull requests in `dayflower/homebrew-tap`.
+
+Action pinning guard, as a GitHub App installed on this repository with `contents: write`:
+
+- `ACTIONS_APP_ID` (repository variable, not a secret): the App ID.
+- `ACTIONS_APP_PRIVATE_KEY`: the App's private key.


### PR DESCRIPTION
Introduces `suzuki-shunsuke/pinact-action`, following the setup already used in `dayflower/live-transcriber`, and resolves code scanning alert #1.

## Action pinning

Third-party actions were referenced by mutable tags (`@v4`, `@v7`, `@v1`), so a retagged upstream release could change what CI executes. The new `pinact` workflow runs on every pull request and pushes a fixup commit when any `uses:` ref is not a full commit SHA. It pushes with a GitHub App token (`vars.ACTIONS_APP_ID` / `secrets.ACTIONS_APP_PRIVATE_KEY`, both already configured on this repository) rather than `GITHUB_TOKEN`, so the fixup commit re-triggers the other workflows; that is also why checkout runs with `persist-credentials: false` and the workflow only grants `contents: read`. pinact-action v3 bundles its own pinact binary, so no aqua setup is needed, and no `.pinact.yaml` is added so the defaults apply.

All existing refs were bumped to their latest releases and then pinned by running `pinact run` locally. Only `actions/checkout` changes version in practice (v4 to v7.0.1); the tags `Apple-Actions/import-codesign-certs@v7` and `dayflower/brew-up@v1` already pointed at the commits released as v7.0.0 and v1.1.0. The breaking changes in checkout v5 through v7 concern fork PR checkout under `pull_request_target` and `workflow_run`, neither of which this repository uses.

## Workflow permissions

`version-consistency.yml` declared no `permissions`, leaving `GITHUB_TOKEN` at the repository default. It now declares `contents: read` at the workflow level, matching the style already used in `release.yml`. This closes https://github.com/dayflower/Signboard/security/code-scanning/1 (`actions/missing-workflow-permissions`).

## Verification

`pinact run --check` exits 0 locally, and all three workflow files parse as valid YAML. The `pinact` and `Version Consistency` checks on this PR exercise the change end to end; `release.yml` is not triggered by pull requests, so its pinned refs are first exercised on the next version bump merge.